### PR TITLE
Add new pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,33 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
+# By default, run each hook only in the standard pre-commit stage
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+
+# This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.0.0
+    rev: v4.1.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+        exclude: ^NOTICE$
         exclude_types: [ markdown ]
       - id: trailing-whitespace
+        exclude: ^NOTICE$
         exclude_types: [ markdown ]
       - id: requirements-txt-fixer
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -30,13 +37,18 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.107.0
+    rev: v1.89.0
     hooks:
       - id: semgrep
   - repo: https://github.com/Yelp/detect-secrets
@@ -48,11 +60,28 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: main
+    rev: v2.0.9
     hooks:
       - id: build-docs
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: copyright
-      # - id: package-app-dependencies
-      # - id: notice-file
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
+      - id: package-app-dependencies
+        language: python
+        additional_dependencies: ["local-hooks"]
+      - id: notice-file
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: release-notes
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: static-tests
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']


### PR DESCRIPTION
- Add the latest pre-commit configuration from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/new-linter-precommit-add-rest`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/new-linter-precommit-add-rest)